### PR TITLE
Update pretrained_models.py

### DIFF
--- a/models/pretrained_models.py
+++ b/models/pretrained_models.py
@@ -259,7 +259,7 @@ class ESMFamily(IPretrainedProteinLanguageModel):
                     logger.log(f' {i} / {len(seq_dataset)} | {time.time() - start:.2f}s ') # | memory usage : {100 - memory_usage.percent:.2f}%
            
 
-
+        os.makedirs(f'./data/{data_type}/embeddings', exist_ok = True)
         torch.save(embs,f'./data/{data_type}/embeddings/{data_type}_{self.version}_embs_layer{layer}_{reduction}.pt')
         t = torch.load(f'./data/{data_type}/embeddings/{data_type}_{self.version}_embs_layer{layer}_{reduction}.pt')
         logger.log(f'Saved embeddings ({t.shape[1]}-d) as "{data_type}_{self.version}_embs_layer{layer}_{reduction}.pt" ({time.time() - start_enc_time:.2f}s)')


### PR DESCRIPTION
Similar as in the other pull request
When the embeddings directory is not present already in the data folder it raises a RuntimeError: Parent directory ./data/<data_type>/embeddings does not exist.

This will create the embeddings folder in that case
Maybe this needs to be added for ProGen2 as well.